### PR TITLE
Updated GitHub account switch behaviour for keycutter list

### DIFF
--- a/lib/github
+++ b/lib/github
@@ -44,7 +44,7 @@ github-auth() {
     log >&2 "GitHub CLI: Logged in as ${logged_in_user}."
 
     read -p "Do you want to switch to another GitHub account? (Y/n) " choice
-    github-check-scopes
+
     choice=${choice:-Y}
 
     if [[ $choice =~ ^[Yy]$ ]]; then

--- a/lib/github
+++ b/lib/github
@@ -43,7 +43,9 @@ github-auth() {
     logged_in_user=$(gh auth status | grep 'account ' | awk '{print $7}')
     log >&2 "GitHub CLI: Logged in as ${logged_in_user}."
 
-    read -p "Do you want to switch to another GitHub account? (Y/n) " choice
+
+    prompt "Do you want to switch to another GitHub account? (Y/n) "
+    read choice
 
     choice=${choice:-Y}
 

--- a/lib/github
+++ b/lib/github
@@ -13,7 +13,7 @@ github-ssh-key-add() {
     fi
 
     prompt "Upload public key to GitHub for auth and commit signing using Github CLI? (Y/n) "
-    read choice
+    read -r choice
     choice=${choice:-Y}
     [[ $choice =~ ^[Yy]*$ ]] || return 1
 
@@ -42,9 +42,9 @@ github-auth() {
   if [[ $auth_status -eq 0 ]]; then
     logged_in_user=$(gh auth status | grep 'account ' | awk '{print $7}')
     log >&2 "GitHub CLI: Logged in as ${logged_in_user}."
-
-    prompt " You're already logged into github.com. Do you want to re-authenticate? (y/N)"
-    read choice
+    
+    prompt " Do you want to switch to another GitHub account? (Y/n)"
+    read -r choice
 
     choice=${choice:-N}
 

--- a/lib/github
+++ b/lib/github
@@ -43,8 +43,7 @@ github-auth() {
     logged_in_user=$(gh auth status | grep 'account ' | awk '{print $7}')
     log >&2 "GitHub CLI: Logged in as ${logged_in_user}."
 
-
-    prompt "You're already logged into github.com. Do you want to re-authenticate? (y/N) "
+    prompt " You're already logged into github.com. Do you want to re-authenticate? (y/N)"
     read choice
 
     choice=${choice:-N}

--- a/lib/github
+++ b/lib/github
@@ -7,11 +7,11 @@ github-ssh-key-add() {
     local ssh_key_path="$1"
     local ssh_keytag="$2"
 
-    if [[ -z "$ssh_keytag" || -z "$ssh_key_path" ]]; then 
+    if [[ -z "$ssh_keytag" || -z "$ssh_key_path" ]]; then
         log "Error: ssh_keytag and ssh_key_path are required."
         return 1
     fi
-    
+
     prompt "Upload public key to GitHub for auth and commit signing using Github CLI? (Y/n) "
     read -p choice
     choice=${choice:-Y}
@@ -35,28 +35,63 @@ github-ssh-key-add() {
 }
 
 github-auth() {
+  # Check if user is logged in to GitHub
+  gh auth status > /dev/null 2>&1
+  auth_status=$?
 
-    # Ensure user is logged in to GitHub with required scopes
+  if [[ $auth_status -eq 0 ]]; then
+    logged_in_user=$(gh auth status | grep 'account ' | awk '{print $7}')
+    log >&2 "GitHub CLI: Logged in as ${logged_in_user}."
 
-    # Show GitHub login status
-    gh auth status 2>&1 | grep 'Logged in to github.com as' >&2
-    # Give user a chance to login or re-login as a different user
+    read -p "Do you want to switch to another GitHub account? (Y/n) " choice
+    github-check-scopes
+    choice=${choice:-Y}
+
+    if [[ $choice =~ ^[Yy]$ ]]; then
+      gh auth logout
+      gh auth login \
+        --web \
+        --git-protocol https \
+        --scopes admin:public_key,admin:ssh_signing_key
+    fi
+
+    github-check-scopes
+
+  elif [[ $auth_status -eq 1 ]]; then
+    log >&2 "GitHub CLI: User is not logged in."
     gh auth login \
       --web \
       --git-protocol https \
       --scopes admin:public_key,admin:ssh_signing_key
 
-    local gh_auth_token_scopes
-    # If user is authenticated to GitHub
-    if gh_auth_token_scopes=$(gh auth status | grep scopes); then 
-      if [[ $gh_auth_token_scopes =~ 'admin:public_key' ]] && [[ $gh_auth_token_scopes =~ 'admin:ssh_signing_key' ]] ; then
-        log >&2 "GitHub CLI: Required scopes are available."
-      else
-        log >&2 "GitHub CLI: Necessary scopes are not available. Requesting additional scopes..."
-        gh auth refresh -h github.com -s admin:public_key,admin:ssh_signing_key
-      fi
-    fi
+  else
+    log >&2 "GitHub CLI: Error: gh auth status returned $auth_status"
+    return 1
+  fi
 }
+
+
+github-check-scopes() {
+  # check scopes
+  if github-auth-required-scopes; then
+    log >&2 "GitHub CLI: Token scopes:$(gh auth status | grep 'scopes' | cut -d':' -f2-)"
+  else
+    log >&2 "GitHub CLI: Missing scopes (admin:public_key, admin:ssh_signing_key). Requesting permissions..."
+    gh auth refresh -h github.com -s admin:public_key,admin:ssh_signing_key
+  fi
+
+}
+
+github-auth-required-scopes() {
+  local github_auth_scopes
+  github_auth_scopes=$(gh auth status | grep scopes)
+  if [[ $github_auth_scopes =~ 'admin:public_key' ]] && [[ $github_auth_scopes =~ 'admin:ssh_signing_key' ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
 
 github-ssh-keys() {
   github-auth

--- a/lib/github
+++ b/lib/github
@@ -13,7 +13,7 @@ github-ssh-key-add() {
     fi
 
     prompt "Upload public key to GitHub for auth and commit signing using Github CLI? (Y/n) "
-    read -r choice
+    read choice
     choice=${choice:-Y}
     [[ $choice =~ ^[Yy]*$ ]] || return 1
 

--- a/lib/github
+++ b/lib/github
@@ -13,7 +13,7 @@ github-ssh-key-add() {
     fi
 
     prompt "Upload public key to GitHub for auth and commit signing using Github CLI? (Y/n) "
-    read -p choice
+    read choice
     choice=${choice:-Y}
     [[ $choice =~ ^[Yy]*$ ]] || return 1
 

--- a/lib/github
+++ b/lib/github
@@ -43,7 +43,7 @@ github-auth() {
     logged_in_user=$(gh auth status | grep 'account ' | awk '{print $7}')
     log >&2 "GitHub CLI: Logged in as ${logged_in_user}."
     
-    prompt " Do you want to switch to another GitHub account? (Y/n)"
+    prompt " Do you want to switch to another GitHub account? (y/N)"
     read -r choice
 
     choice=${choice:-N}

--- a/lib/github
+++ b/lib/github
@@ -44,10 +44,10 @@ github-auth() {
     log >&2 "GitHub CLI: Logged in as ${logged_in_user}."
 
 
-    prompt "Do you want to switch to another GitHub account? (Y/n) "
+    prompt "You're already logged into github.com. Do you want to re-authenticate? (y/N) "
     read choice
 
-    choice=${choice:-Y}
+    choice=${choice:-N}
 
     if [[ $choice =~ ^[Yy]$ ]]; then
       gh auth logout


### PR DESCRIPTION
The goal of this PR is to reduce the confusion associated with how keycutter prompts during `keycutter list`.

Currently it asks a sometimes confusing question about logging into Github - while already logged in?

This change will now instead ask the user if they wish to sign into another account like so:

**not** switching github.com profiles:
```
$ keycutter list
GitHub CLI: Logged in as lukeburciu.
Do you want to switch to another GitHub account? (Y/n) n
GitHub CLI: Token scopes: 'admin:public_key', 'admin:ssh_signing_key', 'gist', 'read:org', 'repo', 'workflow'
TITLE    ID       KEY     TYPE     ADDED
...SSH key details....
```

switching github.com profiles:
```
$ keycutter list
GitHub CLI: Logged in as lukeburciu.
Do you want to switch to another GitHub account? (Y/n) Y
✓ Logged out of github.com account lukeburciu
? Authenticate Git with your GitHub credentials? Yes

! First copy your one-time code: ABCD-1234
Press Enter to open github.com in your browser...
✓ Authentication complete.
- gh config set -h github.com git_protocol https
✓ Configured git protocol
✓ Logged in as lukeburciu
GitHub CLI: Token scopes: 'admin:public_key', 'admin:ssh_signing_key', 'gist', 'read:org', 'repo', 'workflow'
TITLE    ID       KEY     TYPE     ADDED
...SSH key details....
```

Current behaviour, where it immediately asks to auth to Git w/ github.com credentials
```
$ keycutter list                                                                                                                                                         
? Authenticate Git with your GitHub credentials? Yes

! First copy your one-time code: ABCD-1234
```
