### PR TITLE
Git commit sign

### DIFF
--- a/bin/keycutter
+++ b/bin/keycutter
@@ -174,6 +174,21 @@ keycutter-list() {
     github-ssh-keys
 }
 
+keycutter-git-signing-config() {
+    git-ssh-signing-check "$@"
+}
+keycutter-set-git-commit-sign() {
+    git-ssh-signing-setup "$@"
+}
+
+keycutter-enable-commit-signing() {
+    git-commit-signing-enable "$@"
+}
+
+keycutter-disable-commit-signing() {
+    git-commit-signing-disable "$@"
+}
+
 keycutter-update() {
     keycutter-update-git
     check_requirements

--- a/bin/keycutter
+++ b/bin/keycutter
@@ -177,7 +177,7 @@ keycutter-list() {
 keycutter-git-signing-config() {
     git-ssh-signing-check "$@"
 }
-keycutter-set-git-commit-sign() {
+keycutter-git-signing-setup() {
     git-ssh-signing-setup "$@"
 }
 
@@ -187,6 +187,10 @@ keycutter-enable-commit-signing() {
 
 keycutter-disable-commit-signing() {
     git-commit-signing-disable "$@"
+}
+
+keycutter-signing-help() {
+    git-ssh-signing-instructions
 }
 
 keycutter-update() {

--- a/bin/keycutter
+++ b/bin/keycutter
@@ -175,22 +175,22 @@ keycutter-list() {
 }
 
 keycutter-git-signing-config() {
-    git-ssh-signing-check "$@"
+    git-signing-config "$@"
 }
 keycutter-git-signing-setup() {
-    git-ssh-signing-setup "$@"
+    git-signing-setup "$@"
 }
 
-keycutter-enable-commit-signing() {
-    git-commit-signing-enable "$@"
+keycutter-enable-git-commit-signing() {
+    enable-git-commit-signing "$@"
 }
 
-keycutter-disable-commit-signing() {
-    git-commit-signing-disable "$@"
+keycutter-disable-git-commit-signing() {
+    disable-git-commit-signing "$@"
 }
 
-keycutter-signing-help() {
-    git-ssh-signing-instructions
+keycutter-git-signing-help() {
+    git-signing-help
 }
 
 keycutter-update() {

--- a/bin/keycutter
+++ b/bin/keycutter
@@ -181,11 +181,11 @@ keycutter-git-signing-setup() {
     git-signing-setup "$@"
 }
 
-keycutter-enable-git-commit-signing() {
+keycutter-git-commit-signing-enable() {
     enable-git-commit-signing "$@"
 }
 
-keycutter-disable-git-commit-signing() {
+keycutter-git-commit-signing-disable() {
     disable-git-commit-signing "$@"
 }
 

--- a/lib/functions
+++ b/lib/functions
@@ -6,5 +6,6 @@ KEYCUTTER_ROOT="$(readlink -f "$(dirname -- "${BASH_SOURCE[0]:-${0:A}}")/../")"
 [[ -z $SSH_CONNECTION ]] && : ${KEYCUTTER_ORIGIN:="$(hostname -s)"}
 
 source "${KEYCUTTER_ROOT}/lib/github"
+source "${KEYCUTTER_ROOT}/lib/git"
 source "${KEYCUTTER_ROOT}/lib/ssh"
 source "${KEYCUTTER_ROOT}/lib/utils"

--- a/lib/git
+++ b/lib/git
@@ -37,8 +37,8 @@ command-exists() {
 git-version-check() {
     local git_version
     git_version=$(git --version | awk '{print $3}')
-    if [ "$(printf '%s\n' "2.34" "$git_version" | sort -V | head -n1)" = "2.34" ]; then
-        log "Error: Git version 2.34 or higher is required for SSH signing."
+    if [ "$(printf '%s\n' "2.34" "$git_version" | sort -V | head -n1)" != "2.34" ]; then
+        echo "Error: Git version 2.34 or higher is required for SSH signing."
         return 1
     fi
     return 0

--- a/lib/git
+++ b/lib/git
@@ -45,7 +45,7 @@ git-version-check() {
 }
 
 # Function to set up Git SSH signing config
-git-ssh-signing-setup() {
+git-signing-setup() {
     local scope=""
     local ssh_key=""
 
@@ -158,7 +158,7 @@ git-ssh-signing-setup() {
 }
 
 # Function to enable commit signing
-git-commit-signing-enable() {
+enable-git-commit-signing() {
     local scope=""
 
     # Parse arguments
@@ -195,7 +195,7 @@ git-commit-signing-enable() {
 }
 
 # Function to disable commit signing
-git-commit-signing-disable() {
+disable-git-commit-signing() {
     local scope=""
 
     # Parse arguments
@@ -232,7 +232,7 @@ git-commit-signing-disable() {
 }
 
 # Function to check Git SSH signing configuration
-git-ssh-signing-check() {
+git-signing-config() {
     local scope="$1"
 
     if [ -z "$scope" ]; then
@@ -247,26 +247,15 @@ git-ssh-signing-check() {
 }
 
 # Function to print setup instructions
-git-ssh-signing-instructions() {
+git-signing-help() {
     local ssh_key="${1:-$KEYCUTTER_SSH_KEY_DIR}"
     log "Setup instructions:"
     log "1. Create a key via keycutter:"
-    log "   \`keycutter create\`"
+    log "   \`keycutter create github.com_me@pc\`"
     log "2. Make sure the Git SSH signing script is in place:"
     log "   \`keycutter update-ssh-config\`"
     log "3. Set up Git SSH signing:"
     log "   \`keycutter git-signing-setup\`"
-}
-
-# Example usage function
-git-ssh-signing-example() {
-    log "Example usage:"
-    log "source ./git_ssh_signing_functions.sh"
-    log "git-version-check"
-    log "git-ssh-signing-setup --global"
-    log "git-commit-signing-enable global"
-    log "git-ssh-signing-check global"
-    log "git-ssh-signing-instructions"
 }
 
 # If this script is run directly, print example usage

--- a/lib/git
+++ b/lib/git
@@ -47,7 +47,48 @@ git-version-check() {
 # Function to set up Git SSH signing config
 git-ssh-signing-setup() {
     local scope=""
-    local ssh_key="$DEFAULT_SSH_KEY"
+    local ssh_key=""
+
+    # Function to display help
+    show_help() {
+        echo "Usage: git-ssh-signing-setup [OPTIONS] [SSH_KEY_PATH]"
+        echo
+        echo "Set up Git SSH signing configuration."
+        echo
+        echo "Options:"
+        echo "  --global    Set the configuration globally"
+        echo "  --local     Set the configuration locally (default if not specified)"
+        echo "  help        Display this help message"
+        echo
+        echo "If SSH_KEY_PATH is not provided, you'll be prompted to select a key from \$KEYCUTTER_SSH_KEY_DIR"
+    }
+
+    # Function to select SSH key
+    select_ssh_key() {
+        if command -v fzf &> /dev/null; then
+            ssh_key=$(find "$KEYCUTTER_SSH_KEY_DIR" -type f -not -name '*.pub' | fzf --prompt="Select SSH key: " --preview="ssh-keygen -lf {}")
+        else
+            echo "Select an SSH key:"
+            local keys=()
+            while IFS= read -r -d $'\0' file; do
+                keys+=("$file")
+            done < <(find "$KEYCUTTER_SSH_KEY_DIR" -type f -not -name '*.pub' -print0)
+            
+            select key in "${keys[@]}"; do
+                if [ -n "$key" ]; then
+                    ssh_key="$key"
+                    break
+                else
+                    echo "Invalid selection. Please try again."
+                fi
+            done
+        fi
+
+        if [ -z "$ssh_key" ]; then
+            log "No SSH key selected. Exiting."
+            return 1
+        fi
+    }
 
     # Parse arguments
     while [[ $# -gt 0 ]]; do
@@ -59,6 +100,10 @@ git-ssh-signing-setup() {
             --local)
                 scope="local"
                 shift
+                ;;
+            help)
+                show_help
+                return 0
                 ;;
             *)
                 # Assume it's the SSH key path
@@ -74,12 +119,17 @@ git-ssh-signing-setup() {
         scope="local"
     fi
 
+    # If no SSH key was provided, use select_ssh_key function to choose one
+    if [ -z "$ssh_key" ]; then
+        select_ssh_key || return 1
+    fi
+
     # Display proposed changes and ask for confirmation
     log "Proposed Git SSH signing configuration:"
-    log "  Scope: $scope"
-    log "  SSH Key: $ssh_key"
-    log "  gpg.format: ssh"
-    log "  gpg.ssh.program: $HOME/.ssh/keycutter/scripts/git-commit-sign"
+    log " Scope: $scope"
+    log " SSH Key: $ssh_key"
+    log " gpg.format: ssh"
+    log " gpg.ssh.program: $HOME/.ssh/keycutter/scripts/git-commit-sign"
     echo
     prompt "Do you want to apply these changes? (y/N) "
     read -n 1 -r
@@ -94,15 +144,14 @@ git-ssh-signing-setup() {
 
     # Apply the configurations
     git-config-set "$scope" "gpg.format" "ssh"
-    
     local script_path="$HOME/.ssh/keycutter/scripts/git-commit-sign"
     git-config-set "$scope" "gpg.ssh.program" "$script_path"
-    
+
     if [ ! -f "$ssh_key" ]; then
         log "Error: SSH key not found at $ssh_key"
         return 1
     fi
-    
+
     git-config-set "$scope" "user.signingkey" "$ssh_key"
     log "Git SSH signing basic setup complete for $scope config!"
     return 0
@@ -199,14 +248,14 @@ git-ssh-signing-check() {
 
 # Function to print setup instructions
 git-ssh-signing-instructions() {
-    local ssh_key="${1:-$DEFAULT_SSH_KEY}"
+    local ssh_key="${1:-$KEYCUTTER_SSH_KEY_DIR}"
     log "Setup instructions:"
-    log "1. Ensure your SSH key is added to the ssh-agent:"
-    log "   ssh-add $ssh_key"
-    log "2. Make sure the Git SSH signing script is in place and executable:"
-    log "   touch $HOME/.ssh/git-commit-sign"
-    log "   chmod u+x $HOME/.ssh/git-commit-sign"
-    log "3. Copy the Git SSH signing script content into $HOME/.ssh/git-commit-sign"
+    log "1. Create a key via keycutter:"
+    log "   \`keycutter create\`"
+    log "2. Make sure the Git SSH signing script is in place:"
+    log "   \`keycutter update-ssh-config\`"
+    log "3. Set up Git SSH signing:"
+    log "   \`keycutter git-signing-setup\`"
 }
 
 # Example usage function

--- a/lib/git
+++ b/lib/git
@@ -1,0 +1,226 @@
+# Git functions
+
+# Function to set Git config
+git-config-set() {
+    local scope="$1"
+    local key="$2"
+    local value="$3"
+    local config_flag=""
+    [[ "$scope" == "global" ]] && config_flag="--global"
+    
+    git config $config_flag "$key" "$value"
+    log "Set $key to $value ($scope config)"
+}
+
+# Function to get Git config
+git-config-get() {
+    local scope="$1"
+    local key="$2"
+    local config_flag=""
+    [[ "$scope" == "global" ]] && config_flag="--global"
+    
+    local value
+    value=$(git config $config_flag --get "$key")
+    if [ -n "$value" ]; then
+        echo "$value"
+    else
+        echo "Not set"
+    fi
+}
+
+# Function to check if a command exists
+command-exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Check Git version
+git-version-check() {
+    local git_version
+    git_version=$(git --version | awk '{print $3}')
+    if [ "$(printf '%s\n' "2.34" "$git_version" | sort -V | head -n1)" = "2.34" ]; then
+        log "Error: Git version 2.34 or higher is required for SSH signing."
+        return 1
+    fi
+    return 0
+}
+
+# Function to set up Git SSH signing config
+git-ssh-signing-setup() {
+    local scope=""
+    local ssh_key="$DEFAULT_SSH_KEY"
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --global)
+                scope="global"
+                shift
+                ;;
+            --local)
+                scope="local"
+                shift
+                ;;
+            *)
+                # Assume it's the SSH key path
+                ssh_key="$1"
+                shift
+                ;;
+        esac
+    done
+
+    # If no scope was explicitly set, default to local
+    if [ -z "$scope" ]; then
+        log "No scope specified. Defaulting to 'local' config."
+        scope="local"
+    fi
+
+    # Display proposed changes and ask for confirmation
+    log "Proposed Git SSH signing configuration:"
+    log "  Scope: $scope"
+    log "  SSH Key: $ssh_key"
+    log "  gpg.format: ssh"
+    log "  gpg.ssh.program: $HOME/.ssh/keycutter/scripts/git-commit-sign"
+    echo
+    prompt "Do you want to apply these changes? (y/N) "
+    read -n 1 -r
+    echo
+    if [[ ! $REPLY =~ ^[Yy]$ ]]
+    then
+        log "Operation cancelled."
+        return 1
+    fi
+
+    log "Setting up Git SSH signing ($scope config)..."
+
+    # Apply the configurations
+    git-config-set "$scope" "gpg.format" "ssh"
+    
+    local script_path="$HOME/.ssh/keycutter/scripts/git-commit-sign"
+    git-config-set "$scope" "gpg.ssh.program" "$script_path"
+    
+    if [ ! -f "$ssh_key" ]; then
+        log "Error: SSH key not found at $ssh_key"
+        return 1
+    fi
+    
+    git-config-set "$scope" "user.signingkey" "$ssh_key"
+    log "Git SSH signing basic setup complete for $scope config!"
+    return 0
+}
+
+# Function to enable commit signing
+git-commit-signing-enable() {
+    local scope=""
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --global)
+                scope="global"
+                shift
+                ;;
+            --local)
+                scope="local"
+                shift
+                ;;
+            *)
+                log "Error: Unknown option $1"
+                return 1
+                ;;
+        esac
+    done
+
+    # If no scope was explicitly set, default to local
+    if [ -z "$scope" ]; then
+        log "No scope specified. Defaulting to 'local' config."
+        scope="local"
+    fi
+
+    local config_flag=""
+    if [ "$scope" = "global" ]; then
+        config_flag="--global"
+    fi
+
+    git config $config_flag "commit.gpgsign" "true"
+    log "Enabled commit signing for $scope config"
+}
+
+# Function to disable commit signing
+git-commit-signing-disable() {
+    local scope=""
+
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --global)
+                scope="global"
+                shift
+                ;;
+            --local)
+                scope="local"
+                shift
+                ;;
+            *)
+                log "Error: Unknown option $1"
+                return 1
+                ;;
+        esac
+    done
+
+    # If no scope was explicitly set, default to local
+    if [ -z "$scope" ]; then
+        log "No scope specified. Defaulting to 'local' config."
+        scope="local"
+    fi
+
+    local config_flag=""
+    if [ "$scope" = "global" ]; then
+        config_flag="--global"
+    fi
+
+    git config $config_flag --unset "commit.gpgsign"
+    log "Disabled commit signing for $scope config"
+}
+
+# Function to check Git SSH signing configuration
+git-ssh-signing-check() {
+    local scope="$1"
+
+    if [ -z "$scope" ]; then
+        log "Checking Git SSH signing configuration (local config):"
+    else
+        log "Checking Git SSH signing configuration ($scope config):"
+    fi
+    log "gpg.format: $(git-config-get "$scope" gpg.format)"
+    log "gpg.ssh.program: $(git-config-get "$scope" gpg.ssh.program)"
+    log "user.signingkey: $(git-config-get "$scope" user.signingkey)"
+    log "commit.gpgsign: $(git-config-get "$scope" commit.gpgsign)"
+}
+
+# Function to print setup instructions
+git-ssh-signing-instructions() {
+    local ssh_key="${1:-$DEFAULT_SSH_KEY}"
+    log "Setup instructions:"
+    log "1. Ensure your SSH key is added to the ssh-agent:"
+    log "   ssh-add $ssh_key"
+    log "2. Make sure the Git SSH signing script is in place and executable:"
+    log "   touch $HOME/.ssh/git-commit-sign"
+    log "   chmod u+x $HOME/.ssh/git-commit-sign"
+    log "3. Copy the Git SSH signing script content into $HOME/.ssh/git-commit-sign"
+}
+
+# Example usage function
+git-ssh-signing-example() {
+    log "Example usage:"
+    log "source ./git_ssh_signing_functions.sh"
+    log "git-version-check"
+    log "git-ssh-signing-setup --global"
+    log "git-commit-signing-enable global"
+    log "git-ssh-signing-check global"
+    log "git-ssh-signing-instructions"
+}
+
+# If this script is run directly, print example usage
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    example_usage
+fi

--- a/lib/git
+++ b/lib/git
@@ -1,3 +1,20 @@
+# Define colors globally
+color_reset=$(tput sgr0)
+color_local=$(tput setaf 2)  # Green for local
+color_global=$(tput setaf 4) # Blue for global
+
+# Function to format the scope with appropriate color
+format_scope() {
+    local scope="$1"
+    if [[ "$scope" == "local" ]]; then
+        echo "${color_local}${scope}${color_reset}"
+    elif [[ "$scope" == "global" ]]; then
+        echo "${color_global}${scope}${color_reset}"
+    else
+        echo "$scope"  # Default to no color if not local or global
+    fi
+}
+
 # Git functions
 
 # Function to set Git config
@@ -9,7 +26,7 @@ git-config-set() {
     [[ "$scope" == "global" ]] && config_flag="--global"
     
     git config $config_flag "$key" "$value"
-    log "Set $key to $value ($scope config)"
+    log "Set $key to $value ($(format_scope $scope) config)"
 }
 
 # Function to get Git config
@@ -24,7 +41,7 @@ git-config-get() {
     if [ -n "$value" ]; then
         echo "$value"
     else
-        echo "Not set"
+        echo "Not set ($(format_scope $scope) config)"
     fi
 }
 
@@ -126,10 +143,11 @@ git-signing-setup() {
 
     # Display proposed changes and ask for confirmation
     log "Proposed Git SSH signing configuration:"
-    log " Scope: $scope"
+    log " Scope: $(format_scope $scope)"
     log " SSH Key: $ssh_key"
+    log " gpg.ssh.program: ~/.ssh/keycutter/scripts/git-commit-sign"
     log " gpg.format: ssh"
-    log " gpg.ssh.program: $HOME/.ssh/keycutter/scripts/git-commit-sign"
+
     echo
     prompt "Do you want to apply these changes? (y/N) "
     read -n 1 -r
@@ -140,7 +158,7 @@ git-signing-setup() {
         return 1
     fi
 
-    log "Setting up Git SSH signing ($scope config)..."
+    log "Setting up Git SSH signing ($(format_scope $scope) config)..."
 
     # Apply the configurations
     git-config-set "$scope" "gpg.format" "ssh"
@@ -153,15 +171,13 @@ git-signing-setup() {
     fi
 
     git-config-set "$scope" "user.signingkey" "$ssh_key"
-    log "Git SSH signing basic setup complete for $scope config!"
+    log "Git SSH signing basic setup complete for $(format_scope $scope) config!"
     return 0
 }
 
 # Function to enable commit signing
 enable-git-commit-signing() {
     local scope=""
-
-    # Parse arguments
     while [[ $# -gt 0 ]]; do
         case $1 in
             --global)
@@ -179,26 +195,20 @@ enable-git-commit-signing() {
         esac
     done
 
-    # If no scope was explicitly set, default to local
     if [ -z "$scope" ]; then
-        log "No scope specified. Defaulting to 'local' config."
+        log "No scope specified. Defaulting to $(format_scope local) config."
         scope="local"
     fi
 
     local config_flag=""
-    if [ "$scope" = "global" ]; then
-        config_flag="--global"
-    fi
-
+    [[ "$scope" == "global" ]] && config_flag="--global"
     git config $config_flag "commit.gpgsign" "true"
-    log "Enabled commit signing for $scope config"
+    log "Enabled commit signing for $(format_scope $scope) config"
 }
 
 # Function to disable commit signing
 disable-git-commit-signing() {
     local scope=""
-
-    # Parse arguments
     while [[ $# -gt 0 ]]; do
         case $1 in
             --global)
@@ -216,35 +226,45 @@ disable-git-commit-signing() {
         esac
     done
 
-    # If no scope was explicitly set, default to local
     if [ -z "$scope" ]; then
-        log "No scope specified. Defaulting to 'local' config."
+        log "No scope specified. Defaulting to $(format_scope local) config."
         scope="local"
     fi
 
     local config_flag=""
-    if [ "$scope" = "global" ]; then
-        config_flag="--global"
-    fi
-
+    [[ "$scope" == "global" ]] && config_flag="--global"
     git config $config_flag --unset "commit.gpgsign"
-    log "Disabled commit signing for $scope config"
+    log "Disabled commit signing for $(format_scope $scope) config"
 }
 
 # Function to check Git SSH signing configuration
 git-signing-config() {
     local scope="$1"
+    local git_dir=""
+
+    # Get the current Git directory, if available
+    if git rev-parse --show-toplevel &>/dev/null; then
+        git_dir=$(git rev-parse --show-toplevel)
+    else
+        git_dir="Not a Git repository"
+    fi
+
+    if [[ "$scope" != "global" && "$scope" != "local" && -n "$scope" ]]; then
+        log "Invalid scope provided. Scope must be either 'global' or 'local'."
+        return 1
+    fi
 
     if [ -z "$scope" ]; then
-        log "Checking Git SSH signing configuration (local config):"
-    else
-        log "Checking Git SSH signing configuration ($scope config):"
+        scope="local"
     fi
+
+    log "Checking $(format_scope $scope) Git SSH signing configuration for directory: $git_dir"
     log "gpg.format: $(git-config-get "$scope" gpg.format)"
     log "gpg.ssh.program: $(git-config-get "$scope" gpg.ssh.program)"
     log "user.signingkey: $(git-config-get "$scope" user.signingkey)"
     log "commit.gpgsign: $(git-config-get "$scope" commit.gpgsign)"
 }
+
 
 # Function to print setup instructions
 git-signing-help() {

--- a/lib/github
+++ b/lib/github
@@ -7,11 +7,11 @@ github-ssh-key-add() {
     local ssh_key_path="$1"
     local ssh_keytag="$2"
 
-    if [[ -z "$ssh_keytag" || -z "$ssh_key_path" ]]; then
+    if [[ -z "$ssh_keytag" || -z "$ssh_key_path" ]]; then 
         log "Error: ssh_keytag and ssh_key_path are required."
         return 1
     fi
-
+    
     prompt "Upload public key to GitHub for auth and commit signing using Github CLI? (Y/n) "
     read choice
     choice=${choice:-Y}
@@ -35,64 +35,28 @@ github-ssh-key-add() {
 }
 
 github-auth() {
-  # Check if user is logged in to GitHub
-  gh auth status > /dev/null 2>&1
-  auth_status=$?
 
-  if [[ $auth_status -eq 0 ]]; then
-    logged_in_user=$(gh auth status | grep 'account ' | awk '{print $7}')
-    log >&2 "GitHub CLI: Logged in as ${logged_in_user}."
-    
-    prompt " Do you want to switch to another GitHub account? (y/N)"
-    read -r choice
+    # Ensure user is logged in to GitHub with required scopes
 
-    choice=${choice:-N}
-
-    if [[ $choice =~ ^[Yy]$ ]]; then
-      gh auth logout
-      gh auth login \
-        --web \
-        --git-protocol https \
-        --scopes admin:public_key,admin:ssh_signing_key
-    fi
-
-    github-check-scopes
-
-  elif [[ $auth_status -eq 1 ]]; then
-    log >&2 "GitHub CLI: User is not logged in."
+    # Show GitHub login status
+    gh auth status 2>&1 | grep 'Logged in to github.com as' >&2
+    # Give user a chance to login or re-login as a different user
     gh auth login \
       --web \
       --git-protocol https \
       --scopes admin:public_key,admin:ssh_signing_key
 
-  else
-    log >&2 "GitHub CLI: Error: gh auth status returned $auth_status"
-    return 1
-  fi
+    local gh_auth_token_scopes
+    # If user is authenticated to GitHub
+    if gh_auth_token_scopes=$(gh auth status | grep scopes); then 
+      if [[ $gh_auth_token_scopes =~ 'admin:public_key' ]] && [[ $gh_auth_token_scopes =~ 'admin:ssh_signing_key' ]] ; then
+        log >&2 "GitHub CLI: Required scopes are available."
+      else
+        log >&2 "GitHub CLI: Necessary scopes are not available. Requesting additional scopes..."
+        gh auth refresh -h github.com -s admin:public_key,admin:ssh_signing_key
+      fi
+    fi
 }
-
-
-github-check-scopes() {
-  # check scopes
-  if github-auth-required-scopes; then
-    log >&2 "GitHub CLI: Token scopes:$(gh auth status | grep 'scopes' | cut -d':' -f2-)"
-  else
-    log >&2 "GitHub CLI: Missing scopes (admin:public_key, admin:ssh_signing_key). Requesting permissions..."
-    gh auth refresh -h github.com -s admin:public_key,admin:ssh_signing_key
-  fi
-
-}
-
-github-auth-required-scopes() {
-  local github_auth_scopes
-  github_auth_scopes=$(gh auth status | grep scopes)
-  if [[ $github_auth_scopes =~ 'admin:public_key' ]] && [[ $github_auth_scopes =~ 'admin:ssh_signing_key' ]]; then
-    return 0
-  else
-    return 1
-  fi
-}
-
 
 github-ssh-keys() {
   github-auth

--- a/lib/github
+++ b/lib/github
@@ -7,11 +7,11 @@ github-ssh-key-add() {
     local ssh_key_path="$1"
     local ssh_keytag="$2"
 
-    if [[ -z "$ssh_keytag" || -z "$ssh_key_path" ]]; then 
+    if [[ -z "$ssh_keytag" || -z "$ssh_key_path" ]]; then
         log "Error: ssh_keytag and ssh_key_path are required."
         return 1
     fi
-    
+
     prompt "Upload public key to GitHub for auth and commit signing using Github CLI? (Y/n) "
     read choice
     choice=${choice:-Y}
@@ -35,28 +35,64 @@ github-ssh-key-add() {
 }
 
 github-auth() {
+  # Check if user is logged in to GitHub
+  gh auth status > /dev/null 2>&1
+  auth_status=$?
 
-    # Ensure user is logged in to GitHub with required scopes
+  if [[ $auth_status -eq 0 ]]; then
+    logged_in_user=$(gh auth status | grep 'account ' | awk '{print $7}')
+    log >&2 "GitHub CLI: Logged in as ${logged_in_user}."
+    
+    prompt " Do you want to switch to another GitHub account? (y/N)"
+    read -r choice
 
-    # Show GitHub login status
-    gh auth status 2>&1 | grep 'Logged in to github.com as' >&2
-    # Give user a chance to login or re-login as a different user
+    choice=${choice:-N}
+
+    if [[ $choice =~ ^[Yy]$ ]]; then
+      gh auth logout
+      gh auth login \
+        --web \
+        --git-protocol https \
+        --scopes admin:public_key,admin:ssh_signing_key
+    fi
+
+    github-check-scopes
+
+  elif [[ $auth_status -eq 1 ]]; then
+    log >&2 "GitHub CLI: User is not logged in."
     gh auth login \
       --web \
       --git-protocol https \
       --scopes admin:public_key,admin:ssh_signing_key
 
-    local gh_auth_token_scopes
-    # If user is authenticated to GitHub
-    if gh_auth_token_scopes=$(gh auth status | grep scopes); then 
-      if [[ $gh_auth_token_scopes =~ 'admin:public_key' ]] && [[ $gh_auth_token_scopes =~ 'admin:ssh_signing_key' ]] ; then
-        log >&2 "GitHub CLI: Required scopes are available."
-      else
-        log >&2 "GitHub CLI: Necessary scopes are not available. Requesting additional scopes..."
-        gh auth refresh -h github.com -s admin:public_key,admin:ssh_signing_key
-      fi
-    fi
+  else
+    log >&2 "GitHub CLI: Error: gh auth status returned $auth_status"
+    return 1
+  fi
 }
+
+
+github-check-scopes() {
+  # check scopes
+  if github-auth-required-scopes; then
+    log >&2 "GitHub CLI: Token scopes:$(gh auth status | grep 'scopes' | cut -d':' -f2-)"
+  else
+    log >&2 "GitHub CLI: Missing scopes (admin:public_key, admin:ssh_signing_key). Requesting permissions..."
+    gh auth refresh -h github.com -s admin:public_key,admin:ssh_signing_key
+  fi
+
+}
+
+github-auth-required-scopes() {
+  local github_auth_scopes
+  github_auth_scopes=$(gh auth status | grep scopes)
+  if [[ $github_auth_scopes =~ 'admin:public_key' ]] && [[ $github_auth_scopes =~ 'admin:ssh_signing_key' ]]; then
+    return 0
+  else
+    return 1
+  fi
+}
+
 
 github-ssh-keys() {
   github-auth

--- a/ssh_config/scripts/git-commit-sign
+++ b/ssh_config/scripts/git-commit-sign
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 
+set -eo pipefail
+
 # Usage:
+#
 # git config [--global] gpg.format ssh
 # git config [--global] gpg.ssh.program "~/.ssh/keycutter/keys/scripts/git-commit-sign"
 # git config [--global] user.signingkey "~/.ssh/keycutter/keys/{service}_user@{host}"
-# Function to get Git config value, trying local then global
 
+# Function to get Git config value, trying local then global
 get_git_config() {
     local value
     value=$(git config --get "$1")
@@ -20,11 +23,23 @@ if [ -z "$signing_key" ]; then
     echo "Error: No signing key found in Git config (local or global)."
     exit 1
 fi
+
+# Check if the signing key file exists
+if [ ! -f "$signing_key" ]; then
+    log_error "Signing key file '$signing_key' does not exist."
+    exit 1
+fi
+
 # Get the key fingerprint
 key_info=$(ssh-keygen -lf "$signing_key" | awk '{gsub(/[()]/, "", $4); print $4 " " $2}')
 if [ -z "$key_info" ]; then
     echo "Error: Could not retrieve key information."
     exit 1
 fi
-echo "Confirm user presence for key $key_info"
-ssh-keygen -Y sign -n git -f "$signing_key" "$@"
+echo "Confirm user presence for key $key_info" >&2
+
+# Sign the commit
+if ! ssh-keygen -Y sign -n git -f "$signing_key" "$@"; then
+    log_error "Signing failed."
+    exit 1
+fi

--- a/ssh_config/scripts/git-commit-sign
+++ b/ssh_config/scripts/git-commit-sign
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
+
 # Usage:
 # git config [--global] gpg.format ssh
 # git config [--global] gpg.ssh.program "~/.ssh/keycutter/keys/scripts/git-commit-sign"
 # git config [--global] user.signingkey "~/.ssh/keycutter/keys/{service}_user@{host}"
 # Function to get Git config value, trying local then global
+
 get_git_config() {
     local value
     value=$(git config --get "$1")

--- a/ssh_config/scripts/git-commit-sign
+++ b/ssh_config/scripts/git-commit-sign
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -e
+
+# Usage:
+# git config [--global] gpg.format ssh
+# git config [--global] user.signingkey "/path/to/ssh/key"
+# [ git config [--global] gpg.ssh.program "/path/to/this/script" ]
+#
+# Now, when you commit:
+# - If commit.gpgsign is true: Every commit will be signed automatically
+# - Otherwise: Use 'git commit -S' to sign individual commits
+#
+
+# Function to get Git config value, trying local then global
+get_git_config() {
+    local value
+    value=$(git config --get "$1")
+    if [ -z "$value" ]; then
+        value=$(git config --global --get "$1")
+    fi
+    echo "$value"
+}
+
+# Check Git version
+git_version=$(git --version | awk '{print $3}')
+if [ "$(printf '%s\n' "2.34" "$git_version" | sort -V | head -n1)" = "2.34" ]; then
+    echo "Error: Git version 2.34 or higher is required for SSH signing."
+    exit 1
+fi
+
+# Check if SSH agent is running
+if [ -z "$SSH_AUTH_SOCK" ]; then
+    echo "Error: SSH agent is not running. Please start the SSH agent."
+    exit 1
+fi
+
+# Get the signing key
+signing_key=$(get_git_config user.signingkey)
+if [ -z "$signing_key" ]; then
+    echo "Error: No signing key found in Git config (local or global)."
+    exit 1
+fi
+
+# Handle relative paths and expand ~
+signing_key="${signing_key/#\~/$HOME}"
+signing_key=$(realpath -m "$signing_key")
+
+# Check if the key file exists
+if [ ! -f "$signing_key" ]; then
+    echo "Error: Signing key file does not exist: $signing_key"
+    exit 1
+fi
+
+# Check if ssh-keygen supports -Y option
+if ! ssh-keygen -Y sign 2>&1 | grep -q "ssh-keygen -Y sign"; then
+    echo "Error: Your version of ssh-keygen does not support the -Y option for signing."
+    exit 1
+fi
+
+# Get the key fingerprint
+key_info=$(ssh-keygen -lf "$signing_key" | awk '{gsub(/[()]/, "", $4); print $4 " " $2}')
+if [ -z "$key_info" ]; then
+    echo "Error: Could not retrieve key information."
+    exit 1
+fi
+
+echo "Confirm user presence for key $key_info"
+
+# Use quotation marks to handle spaces in paths
+if ! ssh-keygen -Y sign -n git -f "$signing_key" "$@"; then
+    echo "Error: Failed to sign with ssh-keygen."
+    exit 1
+fi
+
+echo "Signing successful."

--- a/ssh_config/scripts/git-commit-sign
+++ b/ssh_config/scripts/git-commit-sign
@@ -1,16 +1,8 @@
 #!/usr/bin/env bash
-set -e
-
 # Usage:
 # git config [--global] gpg.format ssh
-# git config [--global] user.signingkey "/path/to/ssh/key"
-# [ git config [--global] gpg.ssh.program "/path/to/this/script" ]
-#
-# Now, when you commit:
-# - If commit.gpgsign is true: Every commit will be signed automatically
-# - Otherwise: Use 'git commit -S' to sign individual commits
-#
-
+# git config [--global] gpg.ssh.program "~/.ssh/keycutter/keys/scripts/git-commit-sign"
+# git config [--global] user.signingkey "~/.ssh/keycutter/keys/{service}_user@{host}"
 # Function to get Git config value, trying local then global
 get_git_config() {
     local value
@@ -20,56 +12,17 @@ get_git_config() {
     fi
     echo "$value"
 }
-
-# Check Git version
-git_version=$(git --version | awk '{print $3}')
-if [ "$(printf '%s\n' "2.34" "$git_version" | sort -V | head -n1)" = "2.34" ]; then
-    echo "Error: Git version 2.34 or higher is required for SSH signing."
-    exit 1
-fi
-
-# Check if SSH agent is running
-if [ -z "$SSH_AUTH_SOCK" ]; then
-    echo "Error: SSH agent is not running. Please start the SSH agent."
-    exit 1
-fi
-
 # Get the signing key
 signing_key=$(get_git_config user.signingkey)
 if [ -z "$signing_key" ]; then
     echo "Error: No signing key found in Git config (local or global)."
     exit 1
 fi
-
-# Handle relative paths and expand ~
-signing_key="${signing_key/#\~/$HOME}"
-signing_key=$(realpath -m "$signing_key")
-
-# Check if the key file exists
-if [ ! -f "$signing_key" ]; then
-    echo "Error: Signing key file does not exist: $signing_key"
-    exit 1
-fi
-
-# Check if ssh-keygen supports -Y option
-if ! ssh-keygen -Y sign 2>&1 | grep -q "ssh-keygen -Y sign"; then
-    echo "Error: Your version of ssh-keygen does not support the -Y option for signing."
-    exit 1
-fi
-
 # Get the key fingerprint
 key_info=$(ssh-keygen -lf "$signing_key" | awk '{gsub(/[()]/, "", $4); print $4 " " $2}')
 if [ -z "$key_info" ]; then
     echo "Error: Could not retrieve key information."
     exit 1
 fi
-
 echo "Confirm user presence for key $key_info"
-
-# Use quotation marks to handle spaces in paths
-if ! ssh-keygen -Y sign -n git -f "$signing_key" "$@"; then
-    echo "Error: Failed to sign with ssh-keygen."
-    exit 1
-fi
-
-echo "Signing successful."
+ssh-keygen -Y sign -n git -f "$signing_key" "$@"


### PR DESCRIPTION
## git-commit-sign

This PR introduces the use of SSH to sign commits. The PR includes configuration handling, and a workflow for setting up and managing commit signing via ssh keys. It also includes a script to handle a signing workflow

purpose of action is based on the premise that this project seems to revolve around the use of keycutter to cut, manage and set up how a yubikey can be utilised for ssh, git is a primary component of this - in that commits and pushed to remotes using ssh. 

## core inclusions

### 1. gpg commit signing abstraction via ssh
- **`git-signing-setup`**:
  - A guided function for setting up SSH-based commit signing.
  - Allows users to select an SSH key interactively using `fzf` or a manual selection fallback (can keep or remove but i think its nice)
  - Applies configurations like `gpg.format`, `gpg.ssh.program`, and `user.signingkey` 

> example with local config (local means this only applies to the current git repository)
```
$ keycutter git-signing-setup
No scope specified. Defaulting to 'local' config.
Proposed Git SSH signing configuration:
 Scope: local
 SSH Key: /Users/lukeb/.ssh/keycutter/keys/github.com_lukeburciu@lukeb
 gpg.ssh.program: ~/.ssh/keycutter/scripts/git-commit-sign
 gpg.format: ssh

❓ Do you want to apply these changes? (y/N)  y
Setting up Git SSH signing (local config)...
Set gpg.format to ssh (local config)
Set gpg.ssh.program to /Users/lukeb/.ssh/keycutter/scripts/git-commit-sign (local config)
Set user.signingkey to /Users/lukeb/.ssh/keycutter/keys/github.com_lukeburciu@lukeb (local config)
Git SSH signing basic setup complete for local config!  
```

### 2. commit signing management
- **Enable/Disable Signing**:
  - Functions to toggle commit signing with the `commit.gpgsign` flag.
  - Supports both local and global configurations for flexibility.
  - User defined, and not applied by default (this is optional)
  
```
$ keycutter git-commit-signing-disable
No scope specified. Defaulting to local config.
Disabled commit signing for local config

$ keycutter git-signing-config
Checking local Git SSH signing configuration for directory: /Users/lukeb/.local/share/keycutter
gpg.format: ssh
gpg.ssh.program: /Users/lukeb/.ssh/keycutter/scripts/git-commit-sign
user.signingkey: /Users/lukeb/.ssh/keycutter/keys/github.com_lukeburciu@lukeb
commit.gpgsign: Not set (local config)

$ keycutter git-commit-signing-enable
No scope specified. Defaulting to local config.
Enabled commit signing for local config

$ keycutter git-signing-config
Checking local Git SSH signing configuration for directory: /Users/lukeb/.local/share/keycutter
gpg.format: ssh
gpg.ssh.program: /Users/lukeb/.ssh/keycutter/scripts/git-commit-sign
user.signingkey: /Users/lukeb/.ssh/keycutter/keys/github.com_lukeburciu@lukeb
commit.gpgsign: true

```

### 4. checks
- **`git-version-check`**:
  - Git version is 2.34 or higher is needed to support SSH signing.

### 5. validation
- **`git-signing-config`**:
  - Displays current signing config in a structured and clear format.
  - audits existing setups and identify potential issues.

```
$ keycutter git-signing-config
Checking local Git SSH signing configuration for directory: /Users/lukeb/.local/share/keycutter
gpg.format: ssh
gpg.ssh.program: /Users/lukeb/.ssh/keycutter/scripts/git-commit-sign
user.signingkey: /Users/lukeb/.ssh/keycutter/keys/github.com_lukeburciu@lukeb
commit.gpgsign: true
```

### 6. git-commit-sign via `scripts/git-commit-sign`
- **provide functionality for signing commits, prompt user to touch yubikey**
- **Retrieve Configurations**: Fetches `user.signingkey` from local or global Git settings.
- **Validation**:
  - Verifies the presence of the signing key in the Git configuration.
  - Checks the existence of the signing key file before proceeding.
  - Forces a check for user presence before signing (this is somewhat required on macOS for some reason)